### PR TITLE
Compiling on x86_64 RHEL

### DIFF
--- a/bin/os-arch.sh
+++ b/bin/os-arch.sh
@@ -2,6 +2,11 @@
 
 UNAME=$(uname -i)
 
+# RHEL seems to use -m flag
+if [ "$UNAME" == 'unknown' ]; then
+    UNAME=$(uname -m)
+fi
+
 if [ "$UNAME" == 'x86_64' ]; then
     echo 'amd64'
 elif [ "$UNAME" == 'amd64' ]; then


### PR DESCRIPTION
It looks like RHEL returns 'unknown' when 'uname -i' is executed. 

I've updated the  os-arch.sh script to call 'uname -m' if the result of 'uname -i' is 'unknown'.
